### PR TITLE
Handle headers in kraken report files

### DIFF
--- a/lib/Bio/Metagenomics/External/Kraken.pm
+++ b/lib/Bio/Metagenomics/External/Kraken.pm
@@ -382,6 +382,7 @@ sub _kraken_report_command {
         (
             $self->kraken_report_exec,
             '--db', $self->database,
+            '--print_header',
             $infile,
             '>', $outfile,
         )

--- a/lib/Bio/Metagenomics/External/KrakenReport.pm
+++ b/lib/Bio/Metagenomics/External/KrakenReport.pm
@@ -47,6 +47,7 @@ sub _load_info_from_file {
 
     open F, $self->filename or Bio::Metagenomics::Exceptions::FileOpen->throw(error => "filename: '" . $self->filename . "'" );
     while (my $line = <F>) {
+        next if($line =~ /^\#/ || $line =~ /^\s*$/);
         my ($clade_reads, $node_reads, $taxon_letter, $name, $indent_level) = _parse_report_line($line);
         $self->total_reads($self->total_reads + $node_reads);
         if (!defined $taxons{$taxon_letter}) {

--- a/t/Bio/Metagenomics/External/Kraken.t
+++ b/t/Bio/Metagenomics/External/Kraken.t
@@ -64,7 +64,7 @@ is($obj->_add_to_library_command('filename.gz'), "gunzip -c filename.gz > filena
 is($obj->_build_command(), "kraken-build --build --db $db --threads 42 --max-db-size 2 --minimizer-len 11", 'Construct build command');
 is($obj->_clean_command(), "kraken-build --clean --db $db", 'Construct clean command');
 is($obj->_run_kraken_command('out'), "kraken --db $db --threads 42 --output out reads_1.fastq", 'Construct kraken command');
-is($obj->_kraken_report_command('in', 'out'), "kraken-report --db $db in > out", 'Construct kraken report command');
+is($obj->_kraken_report_command('in', 'out'), "kraken-report --db $db --print_header in > out", 'Construct kraken report command');
 
 my @expected_fasta_to_add = (
     {

--- a/t/Bio/Metagenomics/External/KrakenReport.t
+++ b/t/Bio/Metagenomics/External/KrakenReport.t
@@ -151,5 +151,19 @@ ok($obj = Bio::Metagenomics::External::KrakenReport->new(
 
 is_deeply($obj->hits, \@expected);
 
+
+ok($obj = Bio::Metagenomics::External::KrakenReport->new(
+    filename => 't/data/KrakenReport.with_header.report'
+), 'initialise object for a report with a header');
+@expected = (
+          {
+            'clade_reads' => '40',
+            'node_reads' => 10,
+            'name' => 'Domain1',
+            'taxon' => 'D'
+          }
+);
+is_deeply($obj->hits, \@expected, 'results without the header');
+
 done_testing();
 

--- a/t/data/KrakenReport.with_header.report
+++ b/t/data/KrakenReport.with_header.report
@@ -1,0 +1,7 @@
+#Kraken version: 0.10.5-beta
+#Database used: /path/to/database
+ 42.00	10	10	U	0	unclassified
+ 43.00	90	90	-	1	root
+ 43.00	90	90	-	1	  spam
+ 44.00	40	10	D	2	    Domain1
+ 


### PR DESCRIPTION
Add a header to a new kraken report file.
When summerising kraken report files, ignore the header.
Requires a modified version of kraken report