### PR TITLE
Add TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: perl
+perl:
+  - "5.14"
+sudo: false
+install:
+  - "mkdir -p build && cd build"
+  - "mkdir fake_bin && cd fake_bin"
+  - "touch kraken kraken-build kraken-report merge_metaphlan_tables.py  metaphlan_hclust_heatmap.py"
+  - "chmod u+x $(ls) && export PATH=$(pwd):$PATH"
+  - "cd ../.. && cpanm Dist::Zilla"
+  - "dzil authordeps --missing | cpanm"
+  - "dzil listdeps --missing | cpanm"
+script: "dzil test"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 Bio-Metagenomics
 ================
+
+[![Build Status](https://travis-ci.org/sanger-pathogens/Bio-Metagenomics.svg?branch=master)](https://travis-ci.org/sanger-pathogens/Bio-Metagenomics)


### PR DESCRIPTION
This appears to successfully run the tests despite dependencies not actually being installed.   It might be an idea to add some integration tests later but, given Kraken's resource requirements, we should make sure that it is still possible to run the tests on Travis without.