### PR TITLE
Don't exit if download fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ nytprof.out
 /pm_to_blib
 *.o
 *.bs
+*.swp

--- a/lib/Bio/Metagenomics/Genbank.pm
+++ b/lib/Bio/Metagenomics/Genbank.pm
@@ -102,22 +102,24 @@ sub _fasta_is_ok {
 
 sub _get_with_getstore {
     my ($self, $outfile, $filetype, $id) = @_;
+    my $download_url = $self->_download_record_url($filetype, $id);
     foreach my $i (1..$self->max_tries) {
-        print "\tgetstore('" . $self->_download_record_url($filetype, $id) . "', '$outfile');\n";
-        getstore($self->_download_record_url($filetype, $id), $outfile);
+        print "\tgetstore('" . $download_url . "', '$outfile');\n";
+        getstore($download_url, $outfile);
         if (-e $outfile and $self->_filetype($outfile) == $filetype) {
             # There is an empty line at the end of each FASTA record
             # in the file. Remove all empty lines.
             system("sed -i '/^\$/d' $outfile") and die $!;
             # Sometimes 404 error messages get put into the output file.
             # So for FASTA files check that it looks like a fasta file throughout
-            return if ( $filetype != FASTA or ($filetype == FASTA and $self->_fasta_is_ok($outfile)) );
+            return 1 if ( $filetype != FASTA or ($filetype == FASTA and $self->_fasta_is_ok($outfile)) );
         }
 
         unlink $outfile if -e $outfile;
         sleep($self->delay);
     }
-    Bio::Metagenomics::Exceptions::GenbankDownload->throw(error => "Error downloading $id from genbank. Cannot continue");
+    print "ID $id\tWARNING: Could not download $id from '$download_url'. Skipping\n";
+    return 0;
 }
 
 
@@ -137,10 +139,12 @@ sub _download_chunks_from_genbank {
     my ($self, $chunks, $outfile) = @_;
     for my $ids (@{$chunks}) {
         my $tmpfile = "$outfile.$$.tmp";
-        $self->_get_with_getstore($tmpfile, FASTA, $ids);
-        my $cmd = "cat $tmpfile >> $outfile";
-        system($cmd) and die "Error running:\n$cmd\n";
-        unlink $tmpfile;
+        my $download_success = $self->_get_with_getstore($tmpfile, FASTA, $ids);
+        if $download_success {
+            my $cmd = "cat $tmpfile >> $outfile";
+            system($cmd) and die "Error running:\n$cmd\n";
+            unlink $tmpfile;
+        }
     }
 }
 
@@ -161,6 +165,7 @@ sub _download_from_genbank {
     my ($self, $outfile, $filetype, $id) = @_;
     my $original_id = $id;
     my $expected_sequences;
+    my $download_success;
 
     # If it's an assembly ID, then we need to get the sequence record ID
     # of each sequence of the assembly. This is in the assembly report file

--- a/lib/Bio/Metagenomics/Genbank.pm
+++ b/lib/Bio/Metagenomics/Genbank.pm
@@ -151,7 +151,16 @@ sub _download_chunks_from_genbank {
 
 sub _fasta_to_number_of_sequences {
     my ($self, $infile) = @_;
-    open F, $infile or Bio::Metagenomics::Exceptions::FileOpen->throw(error => "Error opening file " . $infile);
+    my $problem_reading_fasta = 0;
+    open F, $infile or $problem_reading_fasta = 1;
+    if $problem_reading_fasta {
+        if ( -e $infile ) {
+            print "WARNING: There was a problem reading the fasta '$infile'; it doesn't exist. Skipping\n";
+        } else {
+            print "WARNING: There was an unknown issue reading the fasta '$infile'. Skipping\n";
+        }
+        return 0;
+    }
     my $sequences = 0;
     while (<F>) {
         $sequences++ if /^>/;
@@ -165,7 +174,6 @@ sub _download_from_genbank {
     my ($self, $outfile, $filetype, $id) = @_;
     my $original_id = $id;
     my $expected_sequences;
-    my $download_success;
 
     # If it's an assembly ID, then we need to get the sequence record ID
     # of each sequence of the assembly. This is in the assembly report file

--- a/t/Bio/Metagenomics/Genbank.t
+++ b/t/Bio/Metagenomics/Genbank.t
@@ -26,7 +26,7 @@ ok($obj = Bio::Metagenomics::Genbank->new(
 my @expected_ids = ('1', '2', '3', 'file_id1', 'file_id2');
 is_deeply($obj->ids_list, \@expected_ids, 'IDs got from list and file OK');
 
-throws_ok{$obj->_download_record_url('notafiletype', 'outfile')} 'Bio::Metagenomics::Exceptions::GenbankUnknownFiletype', 'Throw error if unknwon filetype given';
+throws_ok{$obj->_download_record_url('notafiletype', 'outfile')} 'Bio::Metagenomics::Exceptions::GenbankUnknownFiletype', 'Throw error if unknown filetype given';
 
 is($obj->_download_record_url(Bio::Metagenomics::Genbank::FASTA, 'OUT'), 'http://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&rettype=fasta&retmode=text&id=OUT', 'Generate download URL OK for fasta file');
 is($obj->_download_record_url(Bio::Metagenomics::Genbank::GENBANK, 'OUT'), 'http://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&rettype=gb&retmode=text&id=OUT', 'Generate download URL OK for genbank file');


### PR DESCRIPTION
`metagm_genbank_downloader` used to fail if one of the downloads failed.  This now just logs an error but continues with the remaining downloads.

Addresses ticket 496880