### PR TITLE
Remove autoversioning

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -3,6 +3,7 @@ author = Martin Hunt <mh12@sanger.ac.uk>
 license = GPL_3
 copyright_holder = Wellcome Trust Sanger Institute
 copyright_year = 2014
+version = 0.1.1
 
 [MetaResources]
 homepage = http://www.sanger.ac.uk/
@@ -20,7 +21,6 @@ requires = metaphlan_hclust_heatmap.py
 [@Git]
 [@Starter]
 [AutoPrereqs]
-[AutoVersion]
 [PodWeaver]
 
 [Encoding]


### PR DESCRIPTION
Remove auto-versioning so that we can create versioned builds for conda.